### PR TITLE
Save settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,21 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+	// Configure glob patterns for excluding files and folders.
+    "files.exclude": {
+        "**/.git": true,
+        "**/.DS_Store": true,
+        "**/*.meta": true,
+        "**/*.*.meta": true,
+        "**/*.unity": true,
+        "**/*.unityproj": true,
+        "**/*.mat": true,
+        "**/*.fbx": true,
+        "**/*.FBX": true,
+        "**/*.tga": true,
+        "**/*.cubemap": true,
+        "**/**.prefab": true,
+        "**/Library": true,
+        "**/ProjectSettings": true,
+        "**/Temp": true
+    }
+}

--- a/Assets/AssetStoreTools/Editor/AssetStoreTools.sln.meta
+++ b/Assets/AssetStoreTools/Editor/AssetStoreTools.sln.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 92626a5a7d22e4e7bb068879bcc2d537
+timeCreated: 1446163319
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AssetStoreTools/Editor/AssetStoreTools.userprefs.meta
+++ b/Assets/AssetStoreTools/Editor/AssetStoreTools.userprefs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 232dfa7b24ba44208b1776b3e9b851e1
+timeCreated: 1446163319
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettings.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettings.cs
@@ -40,7 +40,7 @@ namespace Staple.EditorScripts
     [CustomPropertyDrawer(typeof(SpriteSettings))]
     public class SpriteSettingsEditor : PropertyDrawer
     {
-        static readonly string[] dontInclude = new string[] { "Name" };
+        static readonly string[] dontInclude = new string[] { "" };
         static readonly string[] spaceBefore = new string[] { "SpriteMeshType", "GenerateMipMaps", "SpritesheetDataFile" };
         static readonly int[] maxSizes = { 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192 };
 

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
@@ -28,7 +28,6 @@ namespace Staple.EditorScripts
     public class SpriteSettingsConfigEditor : Editor
     {
         private ReorderableList list;
-        private Editor textureSettingsEditor;
 
         private void OnEnable() {
             list = new ReorderableList(serializedObject, 
@@ -46,7 +45,7 @@ namespace Staple.EditorScripts
             list.DoLayoutList();
             
             EditorGUILayout.Space ();
-            EditorGUILayout.LabelField ("Selected Settings", EditorStyles.boldLabel);
+            EditorGUILayout.LabelField ("Selected Settings", EditorStyles.largeLabel);
             
             DrawSelectedSpriteSetting (serializedObject);
             
@@ -85,5 +84,14 @@ namespace Staple.EditorScripts
 		
             return listCopy.intValue;
 		}
+        
+        public void SelectSetting (int settingIndex)
+        {
+            if (settingIndex >= list.count || settingIndex < 0) {
+                return;
+            }
+            
+            list.index = settingIndex;
+        }
     }
 }

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
@@ -19,8 +19,13 @@ namespace Staple.EditorScripts
             SettingsSets = SettingsSets ?? new List<SpriteSettings>();
             if (SettingsSets.Count < 1)
             {
-                SettingsSets.Add(new SpriteSettings());
+                AddDefaultSpriteSetting ();
             }
+        }
+        
+        public void AddDefaultSpriteSetting ()
+        {
+            SettingsSets.Add(new SpriteSettings());
         }
     }
 

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
@@ -12,8 +12,6 @@ namespace Staple.EditorScripts
         // Future ready: Implement sprite settings sets;
         public List<SpriteSettings> SettingsSets;
 
-        public SpriteSettings Settings { get; private set; }
-
         void OnEnable()
         {
             //hideFlags = HideFlags.DontSaveInBuild;
@@ -23,36 +21,19 @@ namespace Staple.EditorScripts
             {
                 SettingsSets.Add(new SpriteSettings());
             }
-
-            Settings = SettingsSets[0];
         }
     }
 
     [CustomEditor(typeof(SpriteSettingsConfig))]
     public class SpriteSettingsConfigEditor : Editor
     {
-        SerializedProperty settings;
-
-        void Awake()
-        {
-            settings = serializedObject.FindProperty("SettingsSets");
-        }
 
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
 
-            if (settings.isArray)
-            {
-                settings.Next(true); // generic field
-                settings.Next(true); // array size field
-
-                // first array index
-                settings.Next(true);
-
-                EditorGUILayout.PropertyField(settings);
-            }
-
+            DrawDefaultInspector ();
+            
             serializedObject.ApplyModifiedProperties();
         }
     }

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
@@ -27,14 +27,63 @@ namespace Staple.EditorScripts
     [CustomEditor(typeof(SpriteSettingsConfig))]
     public class SpriteSettingsConfigEditor : Editor
     {
+        private ReorderableList list;
+        private Editor textureSettingsEditor;
+
+        private void OnEnable() {
+            list = new ReorderableList(serializedObject, 
+                    serializedObject.FindProperty("SettingsSets"), 
+                    true, true, true, true);
+            list.drawHeaderCallback = (Rect rect) => {  
+                EditorGUI.LabelField(rect, "Saved SpriteSettings");
+            };
+        }
 
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
 
-            DrawDefaultInspector ();
+            list.DoLayoutList();
+            
+            EditorGUILayout.Space ();
+            EditorGUILayout.LabelField ("Selected Settings", EditorStyles.boldLabel);
+            
+            DrawSelectedSpriteSetting (serializedObject);
             
             serializedObject.ApplyModifiedProperties();
         }
+        
+        void DrawSelectedSpriteSetting (SerializedObject serializedObject)
+        {
+            int selectedIndex = list.index;
+            
+            SerializedProperty settingsSets = serializedObject.FindProperty ("SettingsSets");
+            
+            if (selectedIndex >= 0) {
+                EditorGUILayout.PropertyField (settingsSets.GetArrayElementAtIndex (selectedIndex));
+            } else {
+                EditorStyles.label.wordWrap = true;
+                if (GetPropertyArraySize (settingsSets) > 0) {
+                    EditorGUILayout.LabelField ("Select a Saved SpriteSetting to edit or remove it.");
+                } else {
+                    EditorGUILayout.LabelField ("No SpriteSettings have been saved. Create a new SpriteSetting from the list above.");
+                }
+            }
+        }
+        
+        int GetPropertyArraySize (SerializedProperty listAsProperty)
+		{
+			if (!listAsProperty.isArray) {
+				return -1;
+			}
+		
+			// Don't iterate on the original
+			SerializedProperty listCopy = listAsProperty.Copy ();
+		
+			listCopy.Next (true); // Skip generic element
+			listCopy.Next (true); // This is the array size
+		
+            return listCopy.intValue;
+		}
     }
 }

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
@@ -76,17 +76,17 @@ namespace Staple.EditorScripts
         }
         
         int GetPropertyArraySize (SerializedProperty listAsProperty)
-		{
-			if (!listAsProperty.isArray) {
-				return -1;
-			}
-		
-			// Don't iterate on the original
-			SerializedProperty listCopy = listAsProperty.Copy ();
-		
-			listCopy.Next (true); // Skip generic element
-			listCopy.Next (true); // This is the array size
-		
+        {
+            if (!listAsProperty.isArray) {
+                return -1;
+            }
+        
+            // Don't iterate on the original
+            SerializedProperty listCopy = listAsProperty.Copy ();
+        
+            listCopy.Next (true); // Skip generic element
+            listCopy.Next (true); // This is the array size
+        
             return listCopy.intValue;
 		}
         

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
@@ -11,6 +11,7 @@ namespace Staple.EditorScripts
     {
         // Future ready: Implement sprite settings sets;
         public List<SpriteSettings> SettingsSets;
+        public const string DefaultPath = "Assets/Editor/QuickSpriteSettings/DefaultSpriteSettings.asset";
 
         void OnEnable()
         {

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs
@@ -22,6 +22,11 @@ namespace Staple.EditorScripts
             configEditor = Editor.CreateEditor (config);
         }
 
+        void OnInspectorUpdate()
+        {
+            Repaint();
+        }
+
         void OnGUI()
         {
             EditorGUILayout.BeginVertical(EditorStyles.inspectorDefaultMargins);

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs
@@ -1,0 +1,41 @@
+﻿using UnityEngine;
+using UnityEditor;
+using System.Collections;
+
+namespace Staple.EditorScripts
+{
+    public class SpriteSettingsConfigWindow : EditorWindow
+    {
+        const string SettingsPath = "Assets/Editor/QuickSpriteSettings/DefaultSpriteSettings.asset";
+        Editor configEditor;
+        private SpriteSettingsConfig config;
+        private Vector2 scrollPos;
+
+        void OnEnable()
+        {
+            config = 
+                AssetDatabase.LoadAssetAtPath(SettingsPath, typeof(SpriteSettingsConfig)) as SpriteSettingsConfig;
+
+            if (config == null)
+                config = ScriptableObjectUtility.CreateAssetAtPath<SpriteSettingsConfig>(SettingsPath);
+                
+            configEditor = Editor.CreateEditor (config);
+        }
+
+        void OnGUI()
+        {
+            EditorGUILayout.BeginVertical(EditorStyles.inspectorDefaultMargins);
+            scrollPos = EditorGUILayout.BeginScrollView (scrollPos);
+            EditorGUILayout.Space ();
+            
+            configEditor.OnInspectorGUI ();
+            
+            EditorGUILayout.EndScrollView ();
+            EditorGUILayout.EndVertical ();
+        }
+        public void SelectSetting (int settingIndex)
+        {
+            ((SpriteSettingsConfigEditor)configEditor).SelectSetting (settingIndex);
+        }
+    }
+}

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs
@@ -6,20 +6,17 @@ namespace Staple.EditorScripts
 {
     public class SpriteSettingsConfigWindow : EditorWindow
     {
-        const string SettingsPath = "Assets/Editor/QuickSpriteSettings/DefaultSpriteSettings.asset";
         Editor configEditor;
         private SpriteSettingsConfig config;
         private Vector2 scrollPos;
 
         void OnEnable()
         {
-            config = 
-                AssetDatabase.LoadAssetAtPath(SettingsPath, typeof(SpriteSettingsConfig)) as SpriteSettingsConfig;
-
-            if (config == null)
-                config = ScriptableObjectUtility.CreateAssetAtPath<SpriteSettingsConfig>(SettingsPath);
-                
-            configEditor = Editor.CreateEditor (config);
+            config = AssetDatabase.LoadAssetAtPath(SpriteSettingsConfig.DefaultPath,
+                 typeof(SpriteSettingsConfig)) as SpriteSettingsConfig;
+            if (config != null) {
+                configEditor = Editor.CreateEditor (config);
+            }
         }
 
         void OnInspectorUpdate()
@@ -29,6 +26,8 @@ namespace Staple.EditorScripts
 
         void OnGUI()
         {
+            if (config == null) return;
+            
             EditorGUILayout.BeginVertical(EditorStyles.inspectorDefaultMargins);
             scrollPos = EditorGUILayout.BeginScrollView (scrollPos);
             EditorGUILayout.Space ();

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs.meta
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7869ac6b0edd6496b997abf5d83bb739
+timeCreated: 1446808945
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
@@ -6,8 +6,6 @@ namespace Staple.EditorScripts
 {
     public class SpriteSettingsWindow : EditorWindow
     {
-        const string SettingsPath = "Assets/Editor/QuickSpriteSettings/DefaultSpriteSettings.asset";
-
         [MenuItem("Assets/Quick Sprite Settings")]
         public static void Init()
         {
@@ -41,11 +39,16 @@ namespace Staple.EditorScripts
 
         void OnEnable()
         {
-            config = 
-                AssetDatabase.LoadAssetAtPath(SettingsPath, typeof(SpriteSettingsConfig)) as SpriteSettingsConfig;
+            LoadOrCreateConfig ();
+        }
+        
+        void LoadOrCreateConfig ()
+        {
+            config = AssetDatabase.LoadAssetAtPath(SpriteSettingsConfig.DefaultPath,
+                typeof(SpriteSettingsConfig)) as SpriteSettingsConfig;
 
             if (config == null)
-                config = ScriptableObjectUtility.CreateAssetAtPath<SpriteSettingsConfig>(SettingsPath);
+                config = ScriptableObjectUtility.CreateAssetAtPath<SpriteSettingsConfig>(SpriteSettingsConfig.DefaultPath);
         }
 
         void OnInspectorUpdate()
@@ -55,9 +58,7 @@ namespace Staple.EditorScripts
 
         void OnGUI()
         {
-            if (config == null) return;
-            
-            if (config.SettingsSets == null || config.SettingsSets.Count == 0) {
+            if (config == null || config.SettingsSets == null || config.SettingsSets.Count == 0) {
                 DrawEmptySaveSettings ();
                 return;
             }
@@ -109,6 +110,9 @@ namespace Staple.EditorScripts
             EditorGUILayout.Space ();
             EditorGUILayout.LabelField ("Create a Saved SpriteSetting to start applying SpriteSettings.");
             if (GUILayout.Button ("Create Setting")) {
+                if (config == null) {
+                    LoadOrCreateConfig ();
+                }
                 EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
                 if (config != null && config.SettingsSets.Count == 0) {
                     config.AddDefaultSpriteSetting ();

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
@@ -31,7 +31,6 @@ namespace Staple.EditorScripts
             return false;
         }
 
-        private Editor textureSettingsEditor;
         private SpriteSettings currentSelectedSettings;
         private int selectedSettingIndex;
         private bool showSettings;
@@ -70,6 +69,8 @@ namespace Staple.EditorScripts
             EditorGUILayout.Space();
             
             DrawSaveSettingSelect ();
+            
+            EditorGUILayout.Space ();
 
             DrawQuickSettings();
 
@@ -110,9 +111,16 @@ namespace Staple.EditorScripts
                 savedSetNames[i] = config.SettingsSets[i].Name;
                 savedSetIndeces[i] = i;
             }
-            selectedSettingIndex = EditorGUILayout.IntPopup ("Saved Settings", selectedSettingIndex, 
+            EditorGUILayout.BeginHorizontal ();
+            selectedSettingIndex = EditorGUILayout.IntPopup ("Setting to Apply", selectedSettingIndex, 
                                                         savedSetNames, savedSetIndeces);
             currentSelectedSettings = config.SettingsSets [selectedSettingIndex];
+            if (GUILayout.Button ("Edit", GUILayout.MaxWidth(80.0f))) {
+                SpriteSettingsConfigWindow window = 
+                    EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
+                window.SelectSetting (selectedSettingIndex);
+            }
+            EditorGUILayout.EndHorizontal ();
         }
 
         void DrawQuickSettings()

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
@@ -77,18 +77,7 @@ namespace Staple.EditorScripts
 
             bodyScrollPos = EditorGUILayout.BeginScrollView(bodyScrollPos);
 
-            DrawSelectedTextureInfo();            
-
-            EditorGUILayout.Space();
-
-            showSettings = EditorGUILayout.Foldout(showSettings, "Default Texture Settings");
-
-            if (showSettings)
-            {
-                textureSettingsEditor = Editor.CreateEditor(config);
-                textureSettingsEditor.OnInspectorGUI();
-                EditorGUILayout.Space();
-            }
+            DrawSelectedTextureInfo();
 
             EditorGUILayout.EndScrollView();
             EditorGUILayout.EndVertical();

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
@@ -58,6 +58,7 @@ namespace Staple.EditorScripts
             if (config == null) return;
             
             if (config.SettingsSets == null || config.SettingsSets.Count == 0) {
+                DrawEmptySaveSettings ();
                 return;
             }
 
@@ -103,6 +104,19 @@ namespace Staple.EditorScripts
             GUI.backgroundColor = defaultBg;
         }
         
+        void DrawEmptySaveSettings ()
+        {
+            EditorGUILayout.Space ();
+            EditorGUILayout.LabelField ("Create a Saved SpriteSetting to start applying SpriteSettings.");
+            if (GUILayout.Button ("Create Setting")) {
+                EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
+                if (config != null && config.SettingsSets.Count == 0) {
+                    config.AddDefaultSpriteSetting ();
+                }
+            }
+            EditorGUILayout.Space ();
+        }
+        
         void DrawSaveSettingSelect ()
         {
             string[] savedSetNames = new string[config.SettingsSets.Count];
@@ -110,6 +124,10 @@ namespace Staple.EditorScripts
             for (int i = 0; i < savedSetNames.Length; i++) {
                 savedSetNames[i] = config.SettingsSets[i].Name;
                 savedSetIndeces[i] = i;
+            }
+            // Make sure a previously selected index still exists
+            if (selectedSettingIndex >= savedSetNames.Length) {
+                selectedSettingIndex = savedSetNames.Length -1;
             }
             EditorGUILayout.BeginHorizontal ();
             selectedSettingIndex = EditorGUILayout.IntPopup ("Setting to Apply", selectedSettingIndex, 

--- a/Assets/Plugins.meta
+++ b/Assets/Plugins.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: bf4c13ff5e2994c629eab305efa75050
+folderAsset: yes
+timeCreated: 1446513338
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Editor.meta
+++ b/Assets/Plugins/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 54ba8ce7bd2fb4657aabdf33c532de34
+folderAsset: yes
+timeCreated: 1446513338
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Editor/VSCode.cs
+++ b/Assets/Plugins/Editor/VSCode.cs
@@ -1,0 +1,1023 @@
+﻿/*
+ * Unity VSCode Support
+ *
+ * Seamless support for Microsoft Visual Studio Code in Unity
+ *
+ * Version:
+ *   2.2
+ *
+ * Authors:
+ *   Matthew Davey <matthew.davey@dotbunny.com>
+ */
+// REQUIRES: VSCode 0.8.0 - Settings directory moved to .vscode
+// TODO: Currently VSCode will not debug mono on Windows -- need a solution.
+namespace dotBunny.Unity
+{
+    using System;
+    using System.IO;
+    using System.Text.RegularExpressions;
+    using UnityEditor;
+    using UnityEngine;
+
+    public static class VSCode
+    {
+        /// <summary>
+        /// Current Version Number
+        /// </summary
+        public const float Version = 2.2f;
+
+        /// <summary>
+        /// Current Version Code
+        /// </summary
+        public const string VersionCode = "-RELEASE";
+
+        #region Properties
+
+        /// <summary>
+        /// Should debug information be displayed in the Unity terminal?
+        /// </summary>
+        public static bool Debug
+        {
+            get
+            {
+                return EditorPrefs.GetBool("VSCode_Debug", false);
+            }
+            set
+            {
+                EditorPrefs.SetBool("VSCode_Debug", value);
+            }
+        }
+
+        /// <summary>
+        /// Is the Visual Studio Code Integration Enabled?
+        /// </summary>
+        /// <remarks>
+        /// We do not want to automatically turn it on, for in larger projects not everyone is using VSCode
+        /// </remarks>
+        public static bool Enabled
+        {
+            get
+            {
+                return EditorPrefs.GetBool("VSCode_Enabled", false);
+            }
+            set
+            {
+                EditorPrefs.SetBool("VSCode_Enabled", value);
+            }
+        }
+
+        /// <summary>
+        /// Should the launch.json file be written?
+        /// </summary>
+        /// <remarks>
+        /// Useful to disable if someone has their own custom one rigged up
+        /// </remarks>
+        public static bool WriteLaunchFile
+        {
+            get
+            {
+                return EditorPrefs.GetBool("VSCode_WriteLaunchFile", true);
+            }
+            set
+            {
+                EditorPrefs.SetBool("VSCode_WriteLaunchFile", value);
+            }
+        }
+
+        /// <summary>
+        /// Should the plugin automatically update itself.
+        /// </summary>
+        static bool AutomaticUpdates
+        {
+            get
+            {
+                return EditorPrefs.GetBool("VSCode_AutomaticUpdates", false);
+            }
+            set
+            {
+                EditorPrefs.SetBool("VSCode_AutomaticUpdates", value);
+            }
+        }
+
+        static float GitHubVersion
+        {
+            get
+            {
+                return EditorPrefs.GetFloat("VSCode_GitHubVersion", Version);
+            }
+            set
+            {
+                EditorPrefs.SetFloat("VSCode_GitHubVersion", value);
+            }
+        }
+
+        /// <summary>
+        /// When was the last time that the plugin was updated?
+        /// </summary>
+        static DateTime LastUpdate
+        {
+            get
+            {
+                // Feature creation date.
+                DateTime lastTime = new DateTime(2015, 10, 8);
+
+                if (EditorPrefs.HasKey("VSCode_LastUpdate"))
+                {
+                    DateTime.TryParse(EditorPrefs.GetString("VSCode_LastUpdate"), out lastTime);
+                }
+                return lastTime;
+            }
+            set
+            {
+                EditorPrefs.SetString("VSCode_LastUpdate", value.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Quick reference to the VSCode launch settings file
+        /// </summary>
+        static string LaunchPath
+        {
+            get
+            {
+                return SettingsFolder + System.IO.Path.DirectorySeparatorChar + "launch.json";
+            }
+        }
+
+        /// <summary>
+        /// The full path to the project
+        /// </summary>
+        static string ProjectPath
+        {
+            get
+            {
+                return System.IO.Path.GetDirectoryName(UnityEngine.Application.dataPath);
+            }
+        }
+
+        /// <summary>
+        /// Quick reference to the VSCode settings folder
+        /// </summary>
+        static string SettingsFolder
+        {
+            get
+            {
+                return ProjectPath + System.IO.Path.DirectorySeparatorChar + ".vscode";
+            }
+        }
+
+        static string SettingsPath
+        {
+
+            get
+            {
+                return SettingsFolder + System.IO.Path.DirectorySeparatorChar + "settings.json";
+            }
+        }
+
+        static int UpdateTime
+        {
+            get
+            {
+                return EditorPrefs.GetInt("VSCode_UpdateTime", 7);
+            }
+            set
+            {
+                EditorPrefs.SetInt("VSCode_UpdateTime", value);
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Integration Constructor
+        /// </summary>
+        static VSCode()
+        {
+            if (Enabled)
+            {
+                UpdateUnityPreferences(true);
+
+                // Add Update Check
+                DateTime targetDate = LastUpdate.AddDays(UpdateTime);
+                if (DateTime.Now >= targetDate)
+                {
+                    CheckForUpdate();
+                }
+            }
+
+
+
+
+            //System.AppDomain.CurrentDomain.DomainUnload += System_AppDomain_CurrentDomain_DomainUnload;
+        }
+
+
+        //  static void System_AppDomain_CurrentDomain_DomainUnload (object sender, System.EventArgs e)
+        //  {
+        //  	if (Enabled) {
+        //  		UpdateUnityPreferences (false);
+        //  	}
+        //  }
+
+        #region Public Members
+
+        /// <summary>
+        /// Force Unity To Write Project File
+        /// </summary>
+        /// <remarks>
+        /// Reflection!
+        /// </remarks>
+        public static void SyncSolution()
+        {
+            System.Type T = System.Type.GetType("UnityEditor.SyncVS,UnityEditor");
+            System.Reflection.MethodInfo SyncSolution = T.GetMethod("SyncSolution", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+            SyncSolution.Invoke(null, null);
+
+        }
+
+        /// <summary>
+        /// Update the solution files so that they work with VS Code
+        /// </summary>
+        public static void UpdateSolution()
+        {
+
+            // No need to process if we are not enabled
+            if (!VSCode.Enabled)
+            {
+                return;
+            }
+
+            if (VSCode.Debug)
+            {
+                UnityEngine.Debug.Log("[VSCode] Updating Solution & Project Files");
+            }
+
+            var currentDirectory = Directory.GetCurrentDirectory();
+            var solutionFiles = Directory.GetFiles(currentDirectory, "*.sln");
+            var projectFiles = Directory.GetFiles(currentDirectory, "*.csproj");
+
+            foreach (var filePath in solutionFiles)
+            {
+                string content = File.ReadAllText(filePath);
+                content = ScrubSolutionContent(content);
+
+                File.WriteAllText(filePath, content);
+
+                ScrubFile(filePath);
+            }
+
+            foreach (var filePath in projectFiles)
+            {
+                string content = File.ReadAllText(filePath);
+                content = ScrubProjectContent(content);
+
+                File.WriteAllText(filePath, content);
+
+                ScrubFile(filePath);
+            }
+
+        }
+
+        #endregion
+
+        #region Private Members
+
+        /// <summary>
+        /// Call VSCode with arguements
+        /// </summary>
+        static void CallVSCode(string args)
+        {
+            System.Diagnostics.Process proc = new System.Diagnostics.Process();
+
+#if UNITY_EDITOR_OSX
+            proc.StartInfo.FileName = "open";
+            proc.StartInfo.Arguments = " -n -b \"com.microsoft.VSCode\" --args " + args;
+            proc.StartInfo.UseShellExecute = false;
+#elif UNITY_EDITOR_WIN
+            proc.StartInfo.FileName = "code";
+            proc.StartInfo.Arguments = args;
+            proc.StartInfo.UseShellExecute = false;
+#else
+            //TODO: Allow for manual path to code?
+            proc.StartInfo.FileName = "code";
+            proc.StartInfo.Arguments = args;
+            proc.StartInfo.UseShellExecute = false;
+#endif
+            proc.StartInfo.RedirectStandardOutput = true;
+            proc.Start();
+        }
+
+        /// <summary>
+        /// Check for Updates with GitHub
+        /// </summary>
+        static void CheckForUpdate()
+        {
+            var fileContent = string.Empty;
+
+            EditorUtility.DisplayProgressBar("VSCode", "Checking for updates ...", 0.5f);
+
+            // Because were not a runtime framework, lets just use the simplest way of doing this
+            try
+            {
+                using (var webClient = new System.Net.WebClient())
+                {
+                    fileContent = webClient.DownloadString("https://raw.githubusercontent.com/dotBunny/VSCode/master/Plugins/Editor/VSCode.cs");
+                }
+            }
+            catch (Exception e)
+            {
+                if (Debug)
+                {
+                    UnityEngine.Debug.Log("[VSCode] " + e.Message);
+                }
+            }
+            finally
+            {
+                EditorUtility.ClearProgressBar();
+            }
+
+            // Set the last update time
+            LastUpdate = DateTime.Now;
+
+            string[] fileExploded = fileContent.Split('\n');
+            if (fileExploded.Length > 7)
+            {
+                float github = Version;
+                if (float.TryParse(fileExploded[6].Replace("*", "").Trim(), out github))
+                {
+                    GitHubVersion = github;
+                }
+
+                if (github > Version)
+                {
+                    var GUIDs = AssetDatabase.FindAssets("t:Script VSCode");
+                    var path = Application.dataPath.Substring(0, Application.dataPath.Length - "/Assets".Length) + System.IO.Path.DirectorySeparatorChar +
+                               AssetDatabase.GUIDToAssetPath(GUIDs[0]).Replace('/', System.IO.Path.DirectorySeparatorChar);
+
+                    if (EditorUtility.DisplayDialog("VSCode Update", "A newer version of the VSCode plugin is available, would you like to update your version?", "Yes", "No"))
+                    {
+                        File.WriteAllText(path, fileContent);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Force Unity Preferences Window To Read From Settings
+        /// </summary>
+        static void FixUnityPreferences()
+        {
+            // I want that window, please and thank you
+            System.Type T = System.Type.GetType("UnityEditor.PreferencesWindow,UnityEditor");
+
+            if (EditorWindow.focusedWindow == null)
+                return;
+
+            // Only run this when the editor window is visible (cause its what screwed us up)
+            if (EditorWindow.focusedWindow.GetType() == T)
+            {
+                var window = EditorWindow.GetWindow(T, true, "Unity Preferences");
+
+
+                if (window == null)
+                {
+                    if (Debug)
+                    {
+                        UnityEngine.Debug.Log("[VSCode] No Preferences Window Found (really?)");
+                    }
+                    return;
+                }
+
+                var invokerType = window.GetType();
+                var invokerMethod = invokerType.GetMethod("ReadPreferences",
+                                        System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+                if (invokerMethod != null)
+                {
+                    invokerMethod.Invoke(window, null);
+                }
+                else if (Debug)
+                {
+                    UnityEngine.Debug.Log("[VSCode] No Reflection Method Found For Preferences");
+                }
+            }
+
+            //  // Get internal integration class
+            //  System.Type iT = System.Type.GetType("UnityEditor.VisualStudioIntegration.UnityVSSupport,UnityEditor.VisualStudioIntegration");
+            //  var iinvokerMethod = iT.GetMethod("ScriptEditorChanged", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+            //  var temp = EditorPrefs.GetString("kScriptsDefaultApp");
+            //  iinvokerMethod.Invoke(null,new object[] { temp } );
+
+        }
+
+        /// <summary>
+        /// Determine what port Unity is listening for on Windows
+        /// </summary>
+        static int GetDebugPort()
+        {
+#if UNITY_EDITOR_WIN
+            System.Diagnostics.Process process = new System.Diagnostics.Process();
+            process.StartInfo.FileName = "netstat";
+            process.StartInfo.Arguments = "-a -n -o -p TCP";
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.Start();
+
+            string output = process.StandardOutput.ReadToEnd();
+            string[] lines = output.Split('\n');
+
+            process.WaitForExit();
+
+            foreach (string line in lines)
+            {
+                string[] tokens = Regex.Split(line, "\\s+");
+                if (tokens.Length > 4)
+                {
+                    int test = -1;
+                    int.TryParse(tokens[5], out test);
+
+                    if (test > 1023)
+                    {
+                        try
+                        {
+                            var p = System.Diagnostics.Process.GetProcessById(test);
+                            if (p.ProcessName == "Unity")
+                            {
+                                return test;
+                            }
+                        }
+                        catch
+                        {
+
+                        }
+                    }
+                }
+            }
+#else
+            System.Diagnostics.Process process = new System.Diagnostics.Process();
+            process.StartInfo.FileName = "lsof";
+            process.StartInfo.Arguments = "-c /^Unity$/ -i 4tcp -a";
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.Start();
+
+            // Not thread safe (yet!)
+            string output = process.StandardOutput.ReadToEnd();
+            string[] lines = output.Split('\n');
+
+            process.WaitForExit();
+
+            foreach (string line in lines)
+            {
+                int port = -1;
+                if (line.StartsWith("Unity"))
+                {
+                    string[] portions = line.Split(new string[] { "TCP *:" }, System.StringSplitOptions.None);
+                    if (portions.Length >= 2)
+                    {
+                        Regex digitsOnly = new Regex(@"[^\d]");
+                        string cleanPort = digitsOnly.Replace(portions[1], "");
+                        if (int.TryParse(cleanPort, out port))
+                        {
+                            if (port > -1)
+                            {
+                                return port;
+                            }
+                        }
+                    }
+                }
+            }
+#endif
+            return -1;
+        }
+
+        // HACK: This is in until Unity can figure out why MD keeps opening even though a different program is selected.
+        [MenuItem("Assets/Open C# Project In Code", false, 1000)]
+        static void MenuOpenProject()
+        {
+            // Force the project files to be sync
+            SyncSolution();
+
+            // Load Project
+            CallVSCode("\"" + ProjectPath + "\" -r");
+        }
+
+        [MenuItem("Assets/Open C# Project In Code", true, 1000)]
+        static bool ValidateMenuOpenProject()
+        {
+            return Enabled;
+        }
+
+        /// <summary>
+        /// VS Code Integration Preferences Item
+        /// </summary>
+        /// <remarks>
+        /// Contains all 3 toggles: Enable/Disable; Debug On/Off; Writing Launch File On/Off
+        /// </remarks>
+        [PreferenceItem("VSCode")]
+        static void VSCodePreferencesItem()
+        {
+            EditorGUILayout.BeginVertical();
+
+            EditorGUILayout.HelpBox("Support development of this plugin, follow @reapazor and @dotbunny on Twitter.", MessageType.Info);
+
+            EditorGUI.BeginChangeCheck();
+
+            Enabled = EditorGUILayout.Toggle(new GUIContent("Enable Integration", "Should the integration work its magic for you?"), Enabled);
+
+            EditorGUILayout.Space();
+
+            EditorGUI.BeginDisabledGroup(!Enabled);
+
+            Debug = EditorGUILayout.Toggle(new GUIContent("Output Messages To Console", "Should informational messages be sent to Unity's Console?"), Debug);
+
+            WriteLaunchFile = EditorGUILayout.Toggle(new GUIContent("Always Write Launch File", "Always write the launch.json settings when entering play mode?"), WriteLaunchFile);
+
+            EditorGUILayout.Space();
+
+            AutomaticUpdates = EditorGUILayout.Toggle(new GUIContent("Automatic Updates", "Should the plugin automatically update itself?"), AutomaticUpdates);
+
+            EditorGUI.BeginDisabledGroup(!AutomaticUpdates);
+
+            UpdateTime = EditorGUILayout.IntSlider(new GUIContent("Update Timer (Days)", "After how many days should updates be checked for?"), UpdateTime, 1, 31);
+
+            EditorGUI.EndDisabledGroup();
+
+            EditorGUI.EndDisabledGroup();
+
+            EditorGUILayout.Space();
+            EditorGUILayout.Space();
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                UpdateUnityPreferences(Enabled);
+
+                //UnityEditor.PreferencesWindow.Read
+
+                // TODO: Force Unity To Reload Preferences
+                // This seems to be a hick up / issue
+
+                if (VSCode.Debug)
+                {
+                    if (Enabled)
+                    {
+                        UnityEngine.Debug.Log("[VSCode] Integration Enabled");
+                    }
+                    else
+                    {
+                        UnityEngine.Debug.Log("[VSCode] Integration Disabled");
+                    }
+                }
+            }
+
+            if (GUILayout.Button(new GUIContent("Force Update", "Check for updates to the plugin, right NOW!")))
+            {
+                CheckForUpdate();
+                EditorGUILayout.EndVertical();
+                return;
+            }
+            if (GUILayout.Button(new GUIContent("Write Workspace Settings", "Output a default set of workspace settings for VSCode to use, ignoring many different types of files.")))
+            {
+                WriteWorkspaceSettings();
+                EditorGUILayout.EndVertical();
+                return;
+            }
+
+            GUILayout.FlexibleSpace();
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+
+            GUILayout.Label(
+                new GUIContent(
+                    string.Format("{0:0.00}", Version) + VersionCode,
+                    "GitHub's Version @ " + string.Format("{0:0.00}", GitHubVersion)));
+
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.EndVertical();
+
+        }
+
+        /// <summary>
+        /// Asset Open Callback (from Unity)
+        /// </summary>
+        /// <remarks>
+        /// Called when Unity is about to open an asset.
+        /// </remarks>
+        [UnityEditor.Callbacks.OnOpenAssetAttribute()]
+        static bool OnOpenedAsset(int instanceID, int line)
+        {
+            // bail out if we are not on a Mac or if we don't want to use VSCode
+            if (!Enabled)
+            {
+                return false;
+            }
+
+            // current path without the asset folder
+            string appPath = ProjectPath;
+
+            // determine asset that has been double clicked in the project view
+            UnityEngine.Object selected = EditorUtility.InstanceIDToObject(instanceID);
+
+            if (selected.GetType().ToString() == "UnityEditor.MonoScript")
+            {
+                string completeFilepath = appPath + Path.DirectorySeparatorChar + AssetDatabase.GetAssetPath(selected);
+
+                string args = null;
+                if (line == -1)
+                {
+
+                    args = "\"" + ProjectPath + "\" \"" + completeFilepath + "\" -r";
+                }
+                else
+                {
+                    args = "\"" + ProjectPath + "\" -g \"" + completeFilepath + ":" + line.ToString() + "\" -r";
+                }
+                // call 'open'
+                CallVSCode(args);
+
+                return true;
+            }
+
+            // Didnt find a code file? let Unity figure it out
+            return false;
+
+        }
+
+        /// <summary>
+        /// Executed when the Editor's playmode changes allowing for capture of required data
+        /// </summary>
+        static void OnPlaymodeStateChanged()
+        {
+            if (VSCode.Enabled && VSCode.WriteLaunchFile && UnityEngine.Application.isPlaying && EditorApplication.isPlayingOrWillChangePlaymode)
+            {
+                int port = GetDebugPort();
+                if (port > -1)
+                {
+                    if (!Directory.Exists(VSCode.SettingsFolder))
+                        System.IO.Directory.CreateDirectory(VSCode.SettingsFolder);
+                    UpdateLaunchFile(port);
+
+                    if (VSCode.Debug)
+                    {
+                        UnityEngine.Debug.Log("[VSCode] Debug Port Found (" + port + ")");
+                    }
+                }
+                else
+                {
+                    if (VSCode.Debug)
+                    {
+                        UnityEngine.Debug.LogWarning("[VSCode] Unable to determine debug port.");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Detect when scripts are reloaded and relink playmode detection
+        /// </summary>
+        [UnityEditor.Callbacks.DidReloadScripts()]
+        static void OnScriptReload()
+        {
+            EditorApplication.playmodeStateChanged -= OnPlaymodeStateChanged;
+            EditorApplication.playmodeStateChanged += OnPlaymodeStateChanged;
+        }
+
+
+        /// <summary>
+        /// Remove extra/erroneous lines from a file.
+        static void ScrubFile(string path)
+        {
+            string[] lines = File.ReadAllLines(path);
+            System.Collections.Generic.List<string> newLines = new System.Collections.Generic.List<string>();
+            for (int i = 0; i < lines.Length; i++)
+            {
+                // Check Empty
+                if (string.IsNullOrEmpty(lines[i].Trim()) || lines[i].Trim() == "\t" || lines[i].Trim() == "\t\t")
+                {
+
+                }
+                else
+                {
+                    newLines.Add(lines[i]);
+                }
+            }
+            File.WriteAllLines(path, newLines.ToArray());
+        }
+
+        /// <summary>
+        /// Remove extra/erroneous data from project file (content).
+        /// </summary>
+        static string ScrubProjectContent(string content)
+        {
+            if (content.Length == 0)
+                return "";
+
+// Note: it causes OmniSharp faults on Windows, such as "not seeing UnityEngine.UI". 3.5 target works fine
+#if !UNITY_EDITOR_WIN
+            // Make sure our reference framework is 2.0, still the base for Unity
+            if (content.IndexOf("<TargetFrameworkVersion>v3.5</TargetFrameworkVersion>") != -1)
+            {
+                content = Regex.Replace(content, "<TargetFrameworkVersion>v3.5</TargetFrameworkVersion>", "<TargetFrameworkVersion>v2.0</TargetFrameworkVersion>");
+            }
+#endif
+
+            string targetPath = "";// "<TargetPath>Temp" + Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar + "Debug" + Path.DirectorySeparatorChar + "</TargetPath>"; //OutputPath
+            string langVersion = "<LangVersion>default</LangVersion>";
+
+
+            bool found = true;
+            int location = 0;
+            string addedOptions = "";
+            int startLocation = -1;
+            int endLocation = -1;
+            int endLength = 0;
+
+            while (found)
+            {
+                startLocation = -1;
+                endLocation = -1;
+                endLength = 0;
+                addedOptions = "";
+                startLocation = content.IndexOf("<PropertyGroup", location);
+
+                if (startLocation != -1)
+                {
+
+                    endLocation = content.IndexOf("</PropertyGroup>", startLocation);
+                    endLength = (endLocation - startLocation);
+
+
+                    if (endLocation == -1)
+                    {
+                        found = false;
+                        continue;
+                    }
+                    else
+                    {
+                        found = true;
+                        location = endLocation;
+                    }
+
+                    if (content.Substring(startLocation, endLength).IndexOf("<TargetPath>") == -1)
+                    {
+                        addedOptions += "\n\r\t" + targetPath + "\n\r";
+                    }
+
+                    if (content.Substring(startLocation, endLength).IndexOf("<LangVersion>") == -1)
+                    {
+                        addedOptions += "\n\r\t" + langVersion + "\n\r";
+                    }
+
+                    if (!string.IsNullOrEmpty(addedOptions))
+                    {
+                        content = content.Substring(0, endLocation) + addedOptions + content.Substring(endLocation);
+                    }
+                }
+                else
+                {
+                    found = false;
+                }
+            }
+
+            return content;
+        }
+
+        /// <summary>
+        /// Remove extra/erroneous data from solution file (content).
+        /// </summary>
+        static string ScrubSolutionContent(string content)
+        {
+            // Replace Solution Version
+            content = content.Replace(
+                "Microsoft Visual Studio Solution File, Format Version 11.00\r\n# Visual Studio 2008\r\n",
+                "\r\nMicrosoft Visual Studio Solution File, Format Version 12.00\r\n# Visual Studio 2012");
+
+            // Remove Solution Properties (Unity Junk)
+            int startIndex = content.IndexOf("GlobalSection(SolutionProperties) = preSolution");
+            if (startIndex != -1)
+            {
+                int endIndex = content.IndexOf("EndGlobalSection", startIndex);
+                content = content.Substring(0, startIndex) + content.Substring(endIndex + 16);
+            }
+
+
+            return content;
+        }
+
+        /// <summary>
+        /// Update Visual Studio Code Launch file
+        /// </summary>
+        static void UpdateLaunchFile(int port)
+        {
+            // Write out proper formatted JSON (hence no more SimpleJSON here)
+            string fileContent = "{\n\t\"version\":\"0.1.0\",\n\t\"configurations\":[ \n\t\t{\n\t\t\t\"name\":\"Unity\",\n\t\t\t\"type\":\"mono\",\n\t\t\t\"address\":\"localhost\",\n\t\t\t\"port\":" + port + "\n\t\t}\n\t]\n}";
+            File.WriteAllText(VSCode.LaunchPath, fileContent);
+        }
+
+        /// <summary>
+        /// Update Unity Editor Preferences
+        static void UpdateUnityPreferences(bool enabled)
+        {
+            if (enabled)
+            {
+#if UNITY_EDITOR_OSX
+                var newPath = "/Applications/Visual Studio Code.app";
+#elif UNITY_EDITOR_WIN
+                var newPath = System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData) + Path.DirectorySeparatorChar + "Code" + Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar + "code.cmd";
+#else
+                var newPath = "/usr/local/bin/code";
+#endif
+
+                // App
+                if (EditorPrefs.GetString("kScriptsDefaultApp") != newPath)
+                {
+                    EditorPrefs.SetString("VSCode_PreviousApp", EditorPrefs.GetString("kScriptsDefaultApp"));
+                }
+                EditorPrefs.SetString("kScriptsDefaultApp", newPath);
+
+                // Arguments
+                if (EditorPrefs.GetString("kScriptEditorArgs") != "-r -g \"$(File):$(Line)\"")
+                {
+                    EditorPrefs.SetString("VSCode_PreviousArgs", EditorPrefs.GetString("kScriptEditorArgs"));
+                }
+
+                EditorPrefs.SetString("kScriptEditorArgs", "-r -g \"$(File):$(Line)\"");
+                EditorPrefs.SetString("kScriptEditorArgs" + newPath, "-r -g \"$(File):$(Line)\"");
+
+
+                // MonoDevelop Solution
+                if (EditorPrefs.GetBool("kMonoDevelopSolutionProperties", false))
+                {
+                    EditorPrefs.SetBool("VSCode_PreviousMD", true);
+                }
+                EditorPrefs.SetBool("kMonoDevelopSolutionProperties", false);
+
+                // Support Unity Proj (JS)
+                if (EditorPrefs.GetBool("kExternalEditorSupportsUnityProj", false))
+                {
+                    EditorPrefs.SetBool("VSCode_PreviousUnityProj", true);
+                }
+                EditorPrefs.SetBool("kExternalEditorSupportsUnityProj", false);
+
+                // Attach to Editor
+                if (!EditorPrefs.GetBool("AllowAttachedDebuggingOfEditor", false))
+                {
+                    EditorPrefs.SetBool("VSCode_PreviousAttach", false);
+                }
+                EditorPrefs.SetBool("AllowAttachedDebuggingOfEditor", true);
+            }
+            else
+            {
+
+                // Restore previous app
+                if (!string.IsNullOrEmpty(EditorPrefs.GetString("VSCode_PreviousApp")))
+                {
+                    EditorPrefs.SetString("kScriptsDefaultApp", EditorPrefs.GetString("VSCode_PreviousApp"));
+                }
+
+                // Restore previous args
+                if (!string.IsNullOrEmpty(EditorPrefs.GetString("VSCode_PreviousArgs")))
+                {
+                    EditorPrefs.SetString("kScriptEditorArgs", EditorPrefs.GetString("VSCode_PreviousArgs"));
+                }
+
+                // Restore MD setting
+                if (EditorPrefs.GetBool("VSCode_PreviousMD", false))
+                {
+                    EditorPrefs.SetBool("kMonoDevelopSolutionProperties", true);
+                }
+
+                // Restore MD setting
+                if (EditorPrefs.GetBool("VSCode_PreviousUnityProj", false))
+                {
+                    EditorPrefs.SetBool("kExternalEditorSupportsUnityProj", true);
+                }
+
+
+                // Restore previous attach
+                if (!EditorPrefs.GetBool("VSCode_PreviousAttach", true))
+                {
+                    EditorPrefs.SetBool("AllowAttachedDebuggingOfEditor", false);
+                }
+            }
+
+            FixUnityPreferences();
+        }
+
+        /// <summary>
+        /// Write Default Workspace Settings
+        /// </summary>
+        static void WriteWorkspaceSettings()
+        {
+            if (Debug)
+            {
+                UnityEngine.Debug.Log("[VSCode] Workspace Settings Written");
+            }
+
+            if (!Directory.Exists(VSCode.SettingsFolder))
+            {
+                System.IO.Directory.CreateDirectory(VSCode.SettingsFolder);
+            }
+
+            string exclusions =
+                "{\n" +
+                "\t\"files.exclude\":\n" +
+                "\t{\n" +
+                // Hidden Files
+                "\t\t\"**/.DS_Store\":true,\n" +
+                "\t\t\"**/.git\":true,\n" +
+                "\t\t\"**/.gitignore\":true,\n" +
+                "\t\t\"**/.gitmodules\":true,\n" +
+
+
+                // Project Files
+                "\t\t\"**/*.booproj\":true,\n" +
+                "\t\t\"**/*.pidb\":true,\n" +
+                "\t\t\"**/*.suo\":true,\n" +
+                "\t\t\"**/*.user\":true,\n" +
+                "\t\t\"**/*.userprefs\":true,\n" +
+                "\t\t\"**/*.unityproj\":true,\n" +
+                "\t\t\"**/*.dll\":true,\n" +
+                "\t\t\"**/*.exe\":true,\n" +
+
+                // Media Files
+                "\t\t\"**/*.pdf\":true,\n" +
+
+                // Audio
+                "\t\t\"**/*.mid\":true,\n" +
+                "\t\t\"**/*.midi\":true,\n" +
+                "\t\t\"**/*.wav\":true,\n" +
+
+                // Textures
+                "\t\t\"**/*.gif\":true,\n" +
+                "\t\t\"**/*.ico\":true,\n" +
+                "\t\t\"**/*.jpg\":true,\n" +
+                "\t\t\"**/*.jpeg\":true,\n" +
+                "\t\t\"**/*.png\":true,\n" +
+                "\t\t\"**/*.psd\":true,\n" +
+                "\t\t\"**/*.tga\":true,\n" +
+                "\t\t\"**/*.tif\":true,\n" +
+                "\t\t\"**/*.tiff\":true,\n" +
+
+                // Models
+                "\t\t\"**/*.3ds\":true,\n" +
+                "\t\t\"**/*.3DS\":true,\n" +
+                "\t\t\"**/*.fbx\":true,\n" +
+                "\t\t\"**/*.FBX\":true,\n" +
+                "\t\t\"**/*.lxo\":true,\n" +
+                "\t\t\"**/*.LXO\":true,\n" +
+                "\t\t\"**/*.ma\":true,\n" +
+                "\t\t\"**/*.MA\":true,\n" +
+                "\t\t\"**/*.obj\":true,\n" +
+                "\t\t\"**/*.OBJ\":true,\n" +
+
+                // Unity File Types
+                "\t\t\"**/*.asset\":true,\n" +
+                "\t\t\"**/*.cubemap\":true,\n" +
+                "\t\t\"**/*.flare\":true,\n" +
+                "\t\t\"**/*.mat\":true,\n" +
+                "\t\t\"**/*.meta\":true,\n" +
+                "\t\t\"**/*.prefab\":true,\n" +
+                "\t\t\"**/*.unity\":true,\n" +
+
+                // Folders
+                "\t\t\"build/\":true,\n" +
+                "\t\t\"Build/\":true,\n" +
+                "\t\t\"Library/\":true,\n" +
+                "\t\t\"library/\":true,\n" +
+                "\t\t\"obj/\":true,\n" +
+                "\t\t\"Obj/\":true,\n" +
+                "\t\t\"ProjectSettings/\":true,\r" +
+                "\t\t\"temp/\":true,\n" +
+                "\t\t\"Temp/\":true\n" +
+                "\t}\n" +
+                "}";
+
+            // Dont like the replace but it fixes the issue with the JSON
+            File.WriteAllText(VSCode.SettingsPath, exclusions);
+        }
+
+        #endregion
+    }
+
+
+
+    /// <summary>
+    /// VSCode Asset AssetPostprocessor
+    /// <para>This will ensure any time that the project files are generated the VSCode versions will be made</para>
+    /// </summary>
+    /// <remarks>Undocumented Event</remarks>
+    public class VSCodeAssetPostprocessor : AssetPostprocessor
+    {
+        /// <summary>
+        /// On documented, project generation event callback
+        /// </summary>
+        private static void OnGeneratedCSProjectFiles()
+        {
+            // Force execution of VSCode update
+            VSCode.UpdateSolution();
+        }
+    }
+}

--- a/Assets/Plugins/Editor/VSCode.cs.meta
+++ b/Assets/Plugins/Editor/VSCode.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d331a764838e54e908f511754cc51c82
+timeCreated: 1446513342
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -3,19 +3,17 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 6
+  serializedVersion: 7
   AndroidProfiler: 0
   defaultScreenOrientation: 4
   targetDevice: 2
-  targetGlesGraphics: -1
-  targetIOSGraphics: -1
   targetResolution: 0
   accelerometerFrequency: 60
   companyName: DefaultCompany
   productName: SpriteSettingsUtility
-  cloudProjectId: 
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
+  m_ShowUnitySplashScreen: 1
   defaultScreenWidth: 1024
   defaultScreenHeight: 768
   defaultScreenWidthWeb: 960
@@ -25,7 +23,6 @@ PlayerSettings:
   m_ActiveColorSpace: 0
   m_MTRendering: 1
   m_MobileMTRendering: 0
-  m_UseDX11: 1
   m_Stereoscopic3D: 0
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
@@ -80,6 +77,7 @@ PlayerSettings:
   metroEnableIndependentInputSource: 0
   metroEnableLowLatencyPresentationAPI: 0
   xboxOneDisableKinectGpuReservation: 0
+  virtualRealitySupported: 0
   productGUID: a1547a515ccc74ce6a1b6980d556af80
   AndroidBundleVersionCode: 1
   AndroidMinSdkVersion: 9
@@ -118,9 +116,11 @@ PlayerSettings:
     serializedVersion: 2
     rgba: 0
   iOSLaunchScreenFillPct: 1
+  iOSLaunchScreenSize: 100
   iOSLaunchScreenCustomXibPath: 
   AndroidTargetDevice: 0
   AndroidSplashScreenScale: 0
+  androidSplashScreen: {fileID: 0}
   AndroidKeystoreName: 
   AndroidKeyaliasName: 
   AndroidTVCompatibility: 1
@@ -130,9 +130,11 @@ PlayerSettings:
   - width: 320
     height: 180
     banner: {fileID: 0}
+  androidGamepadSupportLevel: 0
   resolutionDialogBanner: {fileID: 0}
   m_BuildTargetIcons: []
   m_BuildTargetBatching: []
+  m_BuildTargetGraphicsAPIs: []
   webPlayerTemplate: APPLICATION:Default
   m_TemplateCustomTags: {}
   actionOnDotNetUnhandledException: 1
@@ -194,6 +196,7 @@ PlayerSettings:
   ps4ApplicationParam2: 0
   ps4ApplicationParam3: 0
   ps4ApplicationParam4: 0
+  ps4GarlicHeapSize: 2048
   ps4Passcode: QKhin2EwanevsIbaa1BGOSek9jI5rMy0
   ps4pnSessions: 1
   ps4pnPresence: 1
@@ -205,6 +208,7 @@ PlayerSettings:
   psp2NPTrophyPackPath: 
   psp2NPSupportGBMorGJP: 0
   psp2NPAgeRating: 12
+  psp2NPTitleDatPath: 
   psp2NPCommsID: 
   psp2NPCommunicationsID: 
   psp2NPCommsPassphrase: 
@@ -219,6 +223,7 @@ PlayerSettings:
   psp2PatchOriginalPackage: 
   psp2PackagePassword: JR4REqmzg01rOYJDbON1w1v1IDcKdHcp
   psp2KeystoneFile: 
+  psp2MemoryExpansionMode: 0
   psp2DRMType: 0
   psp2StorageType: 0
   psp2MediaCapacity: 0
@@ -334,8 +339,7 @@ PlayerSettings:
   blackberrySquareSplashScreen: {fileID: 0}
   tizenProductDescription: 
   tizenProductURL: 
-  tizenCertificatePath: 
-  tizenCertificatePassword: 
+  tizenSigningProfileName: 
   tizenGPSPermissions: 0
   tizenMicrophonePermissions: 0
   stvDeviceAddress: 
@@ -354,6 +358,7 @@ PlayerSettings:
   XboxOnePackagingOverridePath: 
   XboxOneAppManifestOverridePath: 
   XboxOnePackageEncryption: 0
+  XboxOnePackageUpdateGranularity: 2
   XboxOneDescription: 
   XboxOneIsContentPackage: 0
   XboxOneEnableGPUVariability: 0
@@ -375,13 +380,22 @@ PlayerSettings:
   iOS::Architecture: 2
   iOS::ScriptingBackend: 0
   boolPropertyNames:
+  - WebGL::analyzeBuildSize
   - WebGL::dataCaching
+  - WebGL::useEmbeddedResources
   - XboxOne::enus
+  WebGL::analyzeBuildSize: 0
   WebGL::dataCaching: 0
+  WebGL::useEmbeddedResources: 0
   XboxOne::enus: 1
   stringPropertyNames:
   - WebGL::emscriptenArgs
   - WebGL::template
   WebGL::emscriptenArgs: 
   WebGL::template: APPLICATION:Default
-  firstStreamedLevelWithResources: 0
+  firstStreamedSceneWithResources: 0
+  cloudProjectId: 
+  projectId: 
+  projectName: 
+  organizationId: 
+  cloudEnabled: 0


### PR DESCRIPTION
First - I'm requesting to merge to master but if you'd like to set up a development branch to better distinguish where the store asset is built from, I can resubmit the PR.

Next some notes on my commit:
- This mostly mirrors what I outlined in Issue #2. I'm not sure it's the optimal flow, but I wanted to evaluate it for a bit.
- I committed the VSCode plugin. We can remove it before merging if you'd prefer. Not sure we really need it in the project.
- My line endings are still screwed up. We should probably do another commit to fix them, after adding a [.gitattributes](https://help.github.com/articles/dealing-with-line-endings/) file to force them to CRLF .
- I added an EditorWindow class for SettingsConfig when I added the "Edit" button from SpriteSettingsWindow. If we only let them edit SettingsConfig from the scriptable object, pressing "Edit" would have to select the scriptable object and they'd lose their texture selection. So the window was a good option. Ultimately, it might even be best to just combine it into the SpriteSettingsWindow somehow.
