### PR TITLE
Removed hardcoded path to config by generating config in the script's directory

### DIFF
--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
@@ -11,7 +11,7 @@ namespace Staple.EditorScripts
     {
         // Future ready: Implement sprite settings sets;
         public List<SpriteSettings> SettingsSets;
-        public const string DefaultPath = "Assets/Editor/QuickSpriteSettings/DefaultSpriteSettings.asset";
+        public const string DefaultFilename = "DefaultSpriteSettings.asset";
 
         void OnEnable()
         {

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs
@@ -9,12 +9,10 @@ namespace Staple.EditorScripts
         Editor configEditor;
         private SpriteSettingsConfig config;
         private Vector2 scrollPos;
-
-        void OnEnable()
-        {
-            config = AssetDatabase.LoadAssetAtPath(SpriteSettingsConfig.DefaultPath,
-                 typeof(SpriteSettingsConfig)) as SpriteSettingsConfig;
-            if (config != null) {
+        
+        public void SetConfig (SpriteSettingsConfig config) {
+            this.config = config;
+            if (this.config != null) {
                 configEditor = Editor.CreateEditor (config);
             }
         }
@@ -26,7 +24,11 @@ namespace Staple.EditorScripts
 
         void OnGUI()
         {
-            if (config == null) return;
+            if (config == null) {
+                EditorGUILayout.HelpBox ("Trying to view Saved SpriteSettings but no settings file exists.", 
+                    MessageType.Error);
+                return;
+            }
             
             EditorGUILayout.BeginVertical(EditorStyles.inspectorDefaultMargins);
             scrollPos = EditorGUILayout.BeginScrollView (scrollPos);
@@ -39,6 +41,9 @@ namespace Staple.EditorScripts
         }
         public void SelectSetting (int settingIndex)
         {
+            if (configEditor == null) {
+                return;
+            }
             ((SpriteSettingsConfigEditor)configEditor).SelectSetting (settingIndex);
         }
     }

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
@@ -39,8 +39,7 @@ namespace Staple.EditorScripts
 
         void OnEnable()
         {
-            config = AssetDatabase.LoadAssetAtPath(SpriteSettingsConfig.DefaultPath,
-                typeof(SpriteSettingsConfig)) as SpriteSettingsConfig;
+            config = AssetDatabase.LoadAssetAtPath(GetPathToConfig (), typeof(SpriteSettingsConfig)) as SpriteSettingsConfig;
         }
 
         void OnInspectorUpdate()
@@ -105,7 +104,9 @@ namespace Staple.EditorScripts
                 if (config == null) {
                     CreateConfig ();
                 }
-                EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
+                
+                ShowConfigWindow (0);
+                
                 if (config.SettingsSets.Count == 0) {
                     config.AddDefaultSpriteSetting ();
                 }
@@ -115,7 +116,23 @@ namespace Staple.EditorScripts
         
         void CreateConfig ()
         {
-            config = ScriptableObjectUtility.CreateAssetAtPath<SpriteSettingsConfig>(SpriteSettingsConfig.DefaultPath);
+            config = ScriptableObjectUtility.CreateAssetAtPath<SpriteSettingsConfig>(GetPathToConfig ());
+        }
+        
+        string GetPathToConfig ()
+        {
+            MonoScript script = MonoScript.FromScriptableObject (this);
+            string scriptPath = AssetDatabase.GetAssetPath (script);
+            string scriptDirectory = System.IO.Path.GetDirectoryName (scriptPath);
+            string filename = SpriteSettingsConfig.DefaultFilename;
+            return scriptDirectory + System.IO.Path.DirectorySeparatorChar + filename;
+        }
+        
+        void ShowConfigWindow (int indexToFocus)
+        {
+                var window = EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
+                window.SetConfig (config);
+                window.SelectSetting (indexToFocus);
         }
         
         void DrawSaveSettingSelect ()
@@ -135,9 +152,7 @@ namespace Staple.EditorScripts
                                                         savedSetNames, savedSetIndeces);
             currentSelectedSettings = config.SettingsSets [selectedSettingIndex];
             if (GUILayout.Button ("Edit", GUILayout.MaxWidth(80.0f))) {
-                SpriteSettingsConfigWindow window = 
-                    EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
-                window.SelectSetting (selectedSettingIndex);
+                ShowConfigWindow (selectedSettingIndex);
             }
             EditorGUILayout.EndHorizontal ();
         }


### PR DESCRIPTION
SpriteSettingsWindow now generates the config file in its directory when it doesn't exist. This allows people to move the QuickSpriteSettings folder wherever they want in their project without erroring. ConfigWindow must now be initialized with a config.
