### PR TITLE
Removes hardcoded path for Config, and other fixes

### DIFF
--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfig.cs
@@ -11,7 +11,7 @@ namespace Staple.EditorScripts
     {
         // Future ready: Implement sprite settings sets;
         public List<SpriteSettings> SettingsSets;
-        public const string DefaultPath = "Assets/Editor/QuickSpriteSettings/DefaultSpriteSettings.asset";
+        public const string DefaultFilename = "DefaultSpriteSettings.asset";
 
         void OnEnable()
         {

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs
@@ -16,6 +16,22 @@ namespace Staple.EditorScripts
                 configEditor = Editor.CreateEditor (config);
             }
         }
+        void OnEnable ()
+        {
+            // Reload config if this window gets rebuilt (which happens when recompiling with an open window)
+            ReloadConfig ();
+        }
+        
+        void ReloadConfig ()
+        {
+            if (config != null) 
+            {
+                config = AssetDatabase.LoadAssetAtPath<SpriteSettingsConfig> (AssetDatabase.GetAssetPath (config));
+                if (this.config != null ) {
+                    configEditor = Editor.CreateEditor (config);
+                }
+            }
+        }
 
         void OnInspectorUpdate()
         {

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsConfigWindow.cs
@@ -9,12 +9,10 @@ namespace Staple.EditorScripts
         Editor configEditor;
         private SpriteSettingsConfig config;
         private Vector2 scrollPos;
-
-        void OnEnable()
-        {
-            config = AssetDatabase.LoadAssetAtPath(SpriteSettingsConfig.DefaultPath,
-                 typeof(SpriteSettingsConfig)) as SpriteSettingsConfig;
-            if (config != null) {
+        
+        public void SetConfig (SpriteSettingsConfig config) {
+            this.config = config;
+            if (this.config != null) {
                 configEditor = Editor.CreateEditor (config);
             }
         }
@@ -26,7 +24,11 @@ namespace Staple.EditorScripts
 
         void OnGUI()
         {
-            if (config == null) return;
+            if (config == null) {
+                EditorGUILayout.HelpBox ("Trying to view Saved SpriteSettings but no settings file exists.", 
+                    MessageType.Error);
+                return;
+            }
             
             EditorGUILayout.BeginVertical(EditorStyles.inspectorDefaultMargins);
             scrollPos = EditorGUILayout.BeginScrollView (scrollPos);
@@ -39,6 +41,9 @@ namespace Staple.EditorScripts
         }
         public void SelectSetting (int settingIndex)
         {
+            if (configEditor == null) {
+                return;
+            }
             ((SpriteSettingsConfigEditor)configEditor).SelectSetting (settingIndex);
         }
     }

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
@@ -36,6 +36,7 @@ namespace Staple.EditorScripts
         private bool changePackingTag;
         private SpriteSettingsConfig config;
         private Vector2 bodyScrollPos;
+        SpriteSettingsConfigWindow configWindow;
 
         void OnEnable()
         {
@@ -92,6 +93,10 @@ namespace Staple.EditorScripts
 				}
                 
                 Close();
+                if (configWindow != null) 
+                {
+                    configWindow.Close ();
+                }
             }
             GUI.backgroundColor = defaultBg;
         }
@@ -130,9 +135,9 @@ namespace Staple.EditorScripts
         
         void ShowConfigWindow (int indexToFocus)
         {
-                var window = EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
-                window.SetConfig (config);
-                window.SelectSetting (indexToFocus);
+                configWindow = EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
+                configWindow.SetConfig (config);
+                configWindow.SelectSetting (indexToFocus);
         }
         
         void DrawSaveSettingSelect ()

--- a/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
+++ b/Assets/Editor/QuickSpriteSettings/SpriteSettingsWindow.cs
@@ -39,8 +39,7 @@ namespace Staple.EditorScripts
 
         void OnEnable()
         {
-            config = AssetDatabase.LoadAssetAtPath(SpriteSettingsConfig.DefaultPath,
-                typeof(SpriteSettingsConfig)) as SpriteSettingsConfig;
+            config = AssetDatabase.LoadAssetAtPath(GetPathToConfig (), typeof(SpriteSettingsConfig)) as SpriteSettingsConfig;
         }
 
         void OnInspectorUpdate()
@@ -105,7 +104,9 @@ namespace Staple.EditorScripts
                 if (config == null) {
                     CreateConfig ();
                 }
-                EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
+                
+                ShowConfigWindow (0);
+                
                 if (config.SettingsSets.Count == 0) {
                     config.AddDefaultSpriteSetting ();
                 }
@@ -115,7 +116,23 @@ namespace Staple.EditorScripts
         
         void CreateConfig ()
         {
-            config = ScriptableObjectUtility.CreateAssetAtPath<SpriteSettingsConfig>(SpriteSettingsConfig.DefaultPath);
+            config = ScriptableObjectUtility.CreateAssetAtPath<SpriteSettingsConfig>(GetPathToConfig ());
+        }
+        
+        string GetPathToConfig ()
+        {
+            MonoScript script = MonoScript.FromScriptableObject (this);
+            string scriptPath = AssetDatabase.GetAssetPath (script);
+            string scriptDirectory = System.IO.Path.GetDirectoryName (scriptPath);
+            string filename = SpriteSettingsConfig.DefaultFilename;
+            return scriptDirectory + System.IO.Path.DirectorySeparatorChar + filename;
+        }
+        
+        void ShowConfigWindow (int indexToFocus)
+        {
+                var window = EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
+                window.SetConfig (config);
+                window.SelectSetting (indexToFocus);
         }
         
         void DrawSaveSettingSelect ()
@@ -135,9 +152,7 @@ namespace Staple.EditorScripts
                                                         savedSetNames, savedSetIndeces);
             currentSelectedSettings = config.SettingsSets [selectedSettingIndex];
             if (GUILayout.Button ("Edit", GUILayout.MaxWidth(80.0f))) {
-                SpriteSettingsConfigWindow window = 
-                    EditorWindow.GetWindow<SpriteSettingsConfigWindow>("Saved SpriteSettings", true);
-                window.SelectSetting (selectedSettingIndex);
+                ShowConfigWindow (selectedSettingIndex);
             }
             EditorGUILayout.EndHorizontal ();
         }


### PR DESCRIPTION
Large PR, I apologize. I've forked the repo and I'm having some issues jumping between projects and figuring out how to merge things. Any tips on improving this workflow would be appreciated.

This PR:
- Removes hardcoded path to the config. This made it hard for users to move the assets within their projects (which is admittedly a bad idea, but still shouldn't error). Previously this resulted in an error trying to create the scriptable object in a folder that didn't exist.
- Closes config window in addition to the QuickSettings window when you "apply" settings.
- Adds a correct Default element when you have an empty list
  *\* This basically addressed a bug where invalid elements were added when you delete all the elements in the Settings, then create one through the +/-, not through the button in the QuickSettings window.
- Fixes a NullReference error that spewed when recompiling code with the Config window open. I think it somehow maintained reference to the Config file, then when trying to re-render its Editor, some internal Reflection operations went wrong. To fix it I re-load the config OnEnable, if it's valid. Seems to work.
